### PR TITLE
Allow pre population of fuzzy finder

### DIFF
--- a/src/fuzzy.nim
+++ b/src/fuzzy.nim
@@ -7,8 +7,18 @@ import std/[os, osproc, parsecfg, sequtils, streams, strutils]
 proc formatForFuzzy(matches: seq[string]): string =
   matches.join("\n")
 
-proc getSelectionFromFuzzy(choices: seq[string], fuzzy: string): string =
-  var p = startProcess(fuzzy, options = {poUsePath})
+proc getSelectionFromFuzzy(
+  choices: seq[string],
+  fuzzy: string,
+  query: string = ""
+): string =
+  var p = startProcess(
+    fuzzy,
+    # TODO - this will break on any fuzzy finders
+    # that don't support --query (thankfully fzy and fzf do)
+    args = ["--query", query],
+    options = {poUsePath}
+  )
 
   let formattedChoices = formatForFuzzy(choices)
 
@@ -26,14 +36,27 @@ proc hasWarnedAboutNoFuzzy(fuzzy: string): bool =
     warn("Try an alternative (fzf or fzy) for this command to work.")
     return true
 
-proc selectFromChoice*(choices: seq[string], config: Config): string =
+proc selectFromChoice*(
+  choices: seq[string],
+  config: Config,
+  query: string = ""
+): string =
   let fuzzy = getFuzzyProvider(config)
 
   if hasWarnedAboutNoFuzzy(fuzzy):
     return
 
-  return getSelectionFromFuzzy(choices, fuzzy)
+  return getSelectionFromFuzzy(choices, fuzzy, query)
 
-proc selectFromDir*(fromDir: string, config: Config): string =
+proc selectFromDir*(
+  fromDir: string,
+  config: Config,
+  query: string = ""
+): string =
   let choices = getFilesForDir(fromDir)
-  return selectFromChoice(choices.mapIt(it.name), config)
+
+  return selectFromChoice(
+    choices.mapIt(it.name),
+    config,
+    query
+  )

--- a/src/subcommands/cat.nim
+++ b/src/subcommands/cat.nim
@@ -1,14 +1,16 @@
-import std/parsecfg
-import std/strutils
+import std/[cmdline, os, parsecfg, strutils]
 import ../config
 import ../fuzzy
 
 const aliases* = @["c", "cat"]
 
 proc process*(config: Config) =
+  var query = commandLineParams()[1..^1].join(" ")
+
   var choice = selectFromDir(
     getNotesPath(config),
-    config
+    config,
+    query
   )
 
   choice.stripLineEnd()

--- a/src/subcommands/edit.nim
+++ b/src/subcommands/edit.nim
@@ -1,6 +1,4 @@
-import std/os
-import std/[osproc, parsecfg]
-import std/strutils
+import std/[cmdline, os, osproc, parsecfg, strutils]
 
 import ../config
 import ../fuzzy
@@ -8,9 +6,12 @@ import ../fuzzy
 const aliases* = @["e", "edit"]
 
 proc process*(config: Config) =
+  var query = commandLineParams()[1..^1].join(" ")
+
   var choice = selectFromDir(
     getNotesPath(config),
-    config
+    config,
+    query
   )
 
   choice.stripLineEnd()

--- a/src/subcommands/mv.nim
+++ b/src/subcommands/mv.nim
@@ -1,7 +1,4 @@
-import std/os
-import std/parsecfg
-import std/strutils
-import std/times
+import std/[os, parsecfg, strutils, times]
 
 import ../config
 import ../fuzzy
@@ -10,9 +7,12 @@ import ../console
 const aliases* = @["mv", "move"]
 
 proc process*(config: Config, flags: seq[string]) =
+  var query = commandLineParams()[1..^1].join(" ")
+
   var choice = selectFromDir(
     getNotesPath(config),
-    config
+    config,
+    query
   )
 
   choice.stripLineEnd()

--- a/src/subcommands/mv.nim
+++ b/src/subcommands/mv.nim
@@ -1,4 +1,4 @@
-import std/[os, parsecfg, strutils, times]
+import std/[cmdline, os, parsecfg, strutils, times]
 
 import ../config
 import ../fuzzy

--- a/src/subcommands/rm.nim
+++ b/src/subcommands/rm.nim
@@ -9,9 +9,12 @@ import ../config
 const aliases* = @["rm", "remove"]
 
 proc process*(config: Config) =
+  var query = commandLineParams()[1..^1].join(" ")
+
   var choice = selectFromDir(
     getNotesPath(config),
-    config
+    config,
+    query
   )
 
   choice.stripLineEnd()

--- a/src/subcommands/rm.nim
+++ b/src/subcommands/rm.nim
@@ -1,7 +1,4 @@
-import std/os
-import std/parsecfg
-import std/strutils
-import std/tempfiles
+import std/[cmdline, os, parsecfg, strutils, tempfiles]
 import ../fuzzy
 import ../console
 import ../config

--- a/src/subcommands/star.nim
+++ b/src/subcommands/star.nim
@@ -12,11 +12,14 @@ import std/symlinks
 const aliases* = @["s", "star"]
 
 proc process*(config: Config) =
+  var query = commandLineParams()[1..^1].join(" ")
+
   discard existsOrCreateDir(Path(getNotesPath(config) & "starred"))
 
   var choice = selectFromDir(
     getNotesPath(config),
-    config
+    config,
+    query
   )
 
   choice.stripLineEnd()

--- a/src/subcommands/star.nim
+++ b/src/subcommands/star.nim
@@ -1,13 +1,8 @@
-import std/strutils
+import std/[cmdline, dirs, os, parsecfg, paths, strutils, symlinks]
 
 import ../config
 import ../fuzzy
 import ../console
-import std/dirs
-import std/os
-import std/paths
-import std/parsecfg
-import std/symlinks
 
 const aliases* = @["s", "star"]
 


### PR DESCRIPTION
Adds in the ability to specify a subcommand to cat, mv, rm, star, and edit.

This subcommand will serve as the `--query` for the fuzzy finder. Meaning that when we do `jn cat my-query`, the fuzzy finder will start with "my-query" already in the search string.

This will make things much more scriptable and in general makes the behaviour more expected from a user's perspective.