### PR TITLE
Add Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ nimcache/
 outputGotten.txt
 testresults/
 
+# Nix result
+result

--- a/build.nimble
+++ b/build.nimble
@@ -1,4 +1,4 @@
-version = "1.1.2"
+version = "1.2.0"
 
 author        = "Joe Reynolds"
 description   = "jn - A filebased CLI notetaker"

--- a/build.nimble
+++ b/build.nimble
@@ -1,4 +1,4 @@
-version = "1.2.0"
+version = "1.1.2"
 
 author        = "Joe Reynolds"
 description   = "jn - A filebased CLI notetaker"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+{
+  buildNimPackage,
+  cacert,
+  openssl,
+}:
+buildNimPackage {
+  pname = "jn";
+  version = "1.2.0";
+
+  src = ./.;
+  buildInputs = [cacert openssl];
+
+  nimFlags = ["-d:ssl" "-d:danger" "--passL:-s" "--mm:arc" "--opt:size"];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Build and/or develop jn";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system;};
+    jn = pkgs.callPackage ./default.nix {};
+  in {
+    packages.${system} = {
+      inherit jn;
+      default = jn;
+    };
+
+    devShell.${system} = pkgs.mkShell {
+      inputsFrom = [jn];
+      packages = with pkgs; [
+        nim
+        nimble
+      ];
+
+      shellHook = ''
+        echo "Entered Nim dev shell"
+        nim --version
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Adds nix package derivation and development shell in a nix flake. Makes `jn` possible to install from the repo for Nix users like myself without having to download a binary. The resulting binary for the nix build is ~300K. I opted not to use the UPX compression after the binary was built, but if you have strong feelings about compressing the binary, it is possible to add it.

With your blessing, I would like to try packaging `jn` for nixpkgs as well, but this is simpler in the short term (I haven't contributed to nixpkgs before and am a bit intimidated haha). 

All tests pass from the development environment spawned with `nix develop`.

```
[mathias@nixnuc:~/dev/jn]$ nix develop
Entered Nim dev shell
Nim Compiler Version 2.2.4 [Linux: amd64]
Compiled at 2025-04-22
Copyright (c) 2006-2025 by Andreas Rumpf

active boot switches: -d:release

[mathias@nixnuc:~/dev/jn]$ nimble test -y
  Compiling /home/mathias/dev/jn/tests/test_categories (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_config (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_files (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_grep (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_tags (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_templates (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_templates_variables_note (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_templates_variables_today (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_todo (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
  Compiling /home/mathias/dev/jn/tests/test_validators (from package build) using c backend
      Info: compiling nim package using /nix/store/ij337g0c1igzgsj9r72wbkc89qgqzjdi-x86_64-unknown-linux-gnu-nim-wrapper-2.2.4/bin/x86_64-unknown-linux-gnu-nim
   Success: Execution finished
   Success: All tests passed
```

P.S. In case it matters, no AI was used for any of this PR.

P.P.S. Thanks for the awesome tool, exactly what I needed.